### PR TITLE
Streamline navigation across portfolio sites

### DIFF
--- a/fabacademyhome.html
+++ b/fabacademyhome.html
@@ -21,7 +21,7 @@
             </div>
             <nav>
                 <ul>
-                    <li><a href="index.html">Home</a></li>
+                    <li><a href="https://blog.perezrobotics.com/">Portfolio Home</a></li>
                     <li><a href="about.html">About Me</a></li>
                     <li><a href="mentoredprojects.html">Mentored Projects</a></li>
                     <li><a href="https://fabacademy.org/2024/labs/hopelab/">The Moonlighter</a></li>

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Peter Perez Portfolio</title>
     <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700&family=Share+Tech+Mono&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="../styles.css">
+    <link rel="stylesheet" href="styles.css">
 </head>
 <body>
     <!-- Sticky Header Container -->
@@ -36,9 +36,10 @@
     <main>
         <section class="grid-container">
             <!-- Placeholder grid items -->
-            <div class="grid-item"><a href="under-construction.html"><img src="images/newhome/PerezSiteIconsRobot.jpg" alt="111-P"></a></div>
+            <div class="grid-item"><a href="under-construction.html"><img src="images/newhome/PerezSiteIconsRobot.jpg" alt="Portfolio Updates"></a></div>
             <div class="grid-item"><a href="mentoredprojects.html"><img src="images/newhome/MentoredPracticumIcon.jpg" alt="Mentored Practicum"></a></div>
-            <div class="grid-item"><a href="fabacademyhome.html"><img src="images/newhome/FabAcademyIcon.jpg" alt="Fab Academy"></a></div>
+            <div class="grid-item"><a href="fabacademyhome.html" target="_blank"><img src="images/newhome/FabAcademyIcon.jpg" alt="Fab Academy"></a></div>
+            <div class="grid-item"><a href="magis-et-ingenium/magis-et-ingenium-home.html"><img src="magis-et-ingenium/mig-images/Magis_et_Ingenium_Seal_Gold.png" alt="Magis et Ingenium Guild"></a></div>
         </section>
     </main>
 

--- a/magis-et-ingenium/magis-et-ingenium-home.html
+++ b/magis-et-ingenium/magis-et-ingenium-home.html
@@ -23,6 +23,7 @@
         <!-- Navigation Bar-->
         <nav>
             <ul class="nav-links">
+                <li><a href="../index.html">Portfolio Home</a></li>
                 <li><a href="m-e-i-guild-register.html">Guild Register</a></li>
                 <li><a href="about.html">About</a></li>
                 <li><a href="#">Contact</a></li>


### PR DESCRIPTION
## Summary
- Fix stylesheet link on main index and add portfolio, Fab Academy, and Magis et Ingenium grid links
- Add link back to main portfolio from Fab Academy page
- Add link back to main portfolio from Magis et Ingenium home page

## Testing
- `npx htmlhint index.html fabacademyhome.html magis-et-ingenium/magis-et-ingenium-home.html` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b98cdfa4b083218d478b9104188bba